### PR TITLE
fix invalid profile

### DIFF
--- a/TRONITY Platform API/module.php
+++ b/TRONITY Platform API/module.php
@@ -1,4 +1,4 @@
-<?php
+<?phpTRONITY.km
 declare(strict_types=1);
 
 require_once __DIR__ . '/../libs/COMMON.php'; 
@@ -553,7 +553,7 @@ require_once __DIR__ . '/../libs/COMMON.php';
 			$varId = $this->RegisterVariableInteger("chargeRemainingTime", "Charge Remaining Time", "", 160);
 			IPS_SetHidden($varId, true);
 
-			$varId = $this->RegisterVariableInteger("odometer", "Odometer", "TRONITY.km", 200);
+			$varId = $this->RegisterVariableInteger("odometer", "Odometer", "EV.km", 200);
 			IPS_SetHidden($varId, true);
 
 			$varId = $this->RegisterVariableFloat("latitude", "Latitude", "", 210);


### PR DESCRIPTION
The TRONITY.km profile is never defined in the module, but EV.km is. Therefore using EV.km as profiles fixes errors while applying the configuration.

![Image 4](https://user-images.githubusercontent.com/260376/161009920-4939ba7d-8cac-4b9b-971d-722ffc1bf465.png)

